### PR TITLE
feat: Client side generation of graph

### DIFF
--- a/packages/site/src/lib/garden/garden.ts
+++ b/packages/site/src/lib/garden/garden.ts
@@ -4,9 +4,10 @@ import { resolve } from "path";
 
 import config from "../../../garden.config";
 import { findFilesDeep } from "./file";
+import { findDeepLinks } from "./gardenGraph";
 import { process } from "./markdown";
 import { FileThing } from "./thing";
-import { ItemLink, Link, LinkType, Meta, Things } from "./types";
+import { ItemLink, Link, Meta, Things } from "./types";
 
 const gardenMetaFile = ".garden-meta.json";
 
@@ -103,53 +104,6 @@ export const findWantedThings = (things: Things) => {
   const knownThings = findKnownThings(things);
   return findLinkedThings(things).filter(
     (name: string) => !knownThings.includes(name)
-  );
-};
-
-const findDeepLinks = (
-  things: Things,
-  name: string,
-  maxDepth: number,
-  depth = 1
-) => {
-  const directLinks = [
-    ...(name in things
-      ? things[name].links.map((link) => ({
-          source: name,
-          target: link.name,
-          depth,
-          type: LinkType.To,
-        }))
-      : []),
-    ...Object.keys(things)
-      .filter((fromName) => {
-        return things[fromName].links.map((link) => link.name).includes(name);
-      })
-      .map((fromName) => ({
-        source: name,
-        target: fromName,
-        depth,
-        type: LinkType.From,
-      })),
-  ];
-  return [
-    ...directLinks,
-    ...(maxDepth < depth + 1
-      ? []
-      : directLinks
-          .map((link) =>
-            findDeepLinks(things, link.target, maxDepth, depth + 1)
-          )
-          .flat()),
-  ].filter(
-    (value, index, self) =>
-      index ===
-      self.findIndex(
-        (compareTo) =>
-          (value.source == compareTo.source &&
-            value.target == compareTo.target) ||
-          (value.source == compareTo.target && value.target == compareTo.source)
-      )
   );
 };
 

--- a/packages/site/src/lib/garden/gardenGraph.ts
+++ b/packages/site/src/lib/garden/gardenGraph.ts
@@ -1,0 +1,48 @@
+import { LinkType, Things } from "./types";
+
+export const findDeepLinks = (
+  things: Things,
+  name: string,
+  maxDepth: number,
+  depth = 1
+) => {
+  const directLinks = [
+    ...(name in things
+      ? things[name].links.map((link) => ({
+          source: name,
+          target: link.name,
+          depth,
+          type: LinkType.To,
+        }))
+      : []),
+    ...Object.keys(things)
+      .filter((fromName) => {
+        return things[fromName].links.map((link) => link.name).includes(name);
+      })
+      .map((fromName) => ({
+        source: name,
+        target: fromName,
+        depth,
+        type: LinkType.From,
+      })),
+  ];
+  return [
+    ...directLinks,
+    ...(maxDepth < depth + 1
+      ? []
+      : directLinks
+          .map((link) =>
+            findDeepLinks(things, link.target, maxDepth, depth + 1)
+          )
+          .flat()),
+  ].filter(
+    (value, index, self) =>
+      index ===
+      self.findIndex(
+        (compareTo) =>
+          (value.source == compareTo.source &&
+            value.target == compareTo.target) ||
+          (value.source == compareTo.target && value.target == compareTo.source)
+      )
+  );
+};

--- a/packages/site/src/pages/[[...name]].tsx
+++ b/packages/site/src/pages/[[...name]].tsx
@@ -7,6 +7,7 @@ import {
   getAllItems,
 } from "../lib/content";
 import { findWantedThings, garden } from "../lib/garden/garden";
+import { findDeepLinks } from "../lib/garden/gardenGraph";
 import { Item, Link, LinkType } from "../lib/garden/types";
 import { createGraph } from "../lib/graph/graph";
 import markdownToHtml from "../lib/markdownToHtml";
@@ -25,7 +26,12 @@ function ItemPage({ item }) {
         </ul>
         <footer>{Object.keys(item.garden).length} things</footer>
       </div>
-      <GraphDiagram graph={item.graph} />
+      <GraphDiagram
+        graph={createGraph(
+          item.garden,
+          findDeepLinks(item.garden, item.name, 2)
+        )}
+      />
     </>
   );
 }
@@ -83,7 +89,6 @@ export async function getStaticProps({ params }) {
         links,
         content,
         garden: things,
-        graph: createGraph(things, garden.findDeepLinks(things, item.name, 2)),
       },
     },
   };


### PR DESCRIPTION
No need in pre-building, better to wait for client to request page and generate on the fly client side. Preparing graph data for each page in build is excessive - slower builds, bigger build bundles.