### PR TITLE
⚡️ cache backlinks when finding deep links

### DIFF
--- a/packages/graph/src/renderGraph.ts
+++ b/packages/graph/src/renderGraph.ts
@@ -122,7 +122,7 @@ const newTick =
     yOffset: number
   ) =>
   () => {
-    if (Math.random() > 0.8) {
+    if (Math.random() > 0.4) {
       return;
     }
     svg


### PR DESCRIPTION
For example on a large graph I see 2 second load reduced to 100ms