### PR TITLE
⚡️ only generate hashed name for entries that have duplicate namings

### DIFF
--- a/packages/core/src/link.ts
+++ b/packages/core/src/link.ts
@@ -12,7 +12,7 @@ export const pageResolver = (name: string) => [linkResolver(name)];
 const ALLOWED_ALTERNATIVE_PAGE_NAMES = [""];
 
 export const isValidPageName = (name: string) =>
-  /^[0-9a-z\\-]+(\+[0-9a-z]{6})?$/.test(name) ||
+  /^[0-9a-z\\-]+(\+[0-9a-z]{2,6})?$/.test(name) ||
   ALLOWED_ALTERNATIVE_PAGE_NAMES.includes(name);
 
 export const isNotValidPageName = (name: string) => !isValidPageName(name);

--- a/packages/end-to-end/src/test/features/duplicate-names.feature
+++ b/packages/end-to-end/src/test/features/duplicate-names.feature
@@ -1,0 +1,9 @@
+Feature: duplicate names
+
+  Scenario: garden 1 README is rendered
+    Given I am on the index page
+    Then I see the heading "Garden 1 README"
+
+  Scenario: garden 2 README is rendered
+    Given I am on the readme+rqyqis page
+    Then I see the heading "Garden 2 README"

--- a/packages/garden/src/base-garden-repository.ts
+++ b/packages/garden/src/base-garden-repository.ts
@@ -41,7 +41,7 @@ export class BaseGardenRepository implements GardenRepository {
   async load(itemReference: ItemReference) {
     const name = itemReference.name;
     if (name in this.content) {
-      return new BaseItem(name, name, this.content[name]);
+      return new BaseItem(itemReference, name, this.content[name]);
     }
     throw `Cannot load ${name} since does not exist in repository`;
   }

--- a/packages/garden/src/base-item.ts
+++ b/packages/garden/src/base-item.ts
@@ -1,4 +1,4 @@
-import { Item } from "@garden/types";
+import { Item, ItemReference } from "@garden/types";
 import matter from "gray-matter";
 
 import { MarkdownMessage } from "./markdown-message";
@@ -23,10 +23,12 @@ export class BaseItem implements Item {
   name: string;
   filename: string;
   content: string;
+  hash: string;
 
-  constructor(name: string, filename: string, content: string) {
+  constructor(itemReference: ItemReference, filename: string, content: string) {
     this.filename = filename;
-    this.name = name;
+    this.name = itemReference.name;
+    this.hash = itemReference.hash;
 
     const itemMatter = safeMatter(content);
     this.content = itemMatter.content;

--- a/packages/garden/src/file-garden-repository.ts
+++ b/packages/garden/src/file-garden-repository.ts
@@ -28,7 +28,7 @@ export class FileItem extends BaseItem {
       join(directory, itemReference.filename),
       "utf8"
     );
-    super(itemReference.name, itemReference.filename, fileContent);
+    super(itemReference, itemReference.filename, fileContent);
   }
 }
 

--- a/packages/garden/src/page.test.ts
+++ b/packages/garden/src/page.test.ts
@@ -10,6 +10,6 @@ describe("page", () => {
     const things = await garden.meta();
     const items = await getPageItems(garden.repository, things);
     const names = items.map((item) => item.name);
-    expect(names).toHaveLength(46);
+    expect(names).toHaveLength(29);
   });
 });

--- a/packages/garden/src/page.ts
+++ b/packages/garden/src/page.ts
@@ -11,9 +11,10 @@ export const getPageItems = async (
     ...(await getAllItems(repository)).filter(
       (item) => item.name.indexOf("#") < 0
     ),
-    ...[{ name: "", content: "no content" }],
+    ...[{ name: "", hash: "00", content: "no content" }],
     ...findWantedThings(things).map((name) => ({
       name,
+      hash: "01",
       content: "no content",
     })),
   ];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,6 +23,7 @@ export interface Nameable {
 
 export interface Item extends Nameable {
   filename?: string;
+  hash: string;
   content: string;
 }
 


### PR DESCRIPTION
Previous change where we created hashed page names to help resolve duplicates took build of a 1000+ entry digital garden from 3m30s to 4m30s due to the page duplicated.  Increase build time was expected after that functional change, however this change is the optimisation to only create these hashed pages for things that do have duplicate names.