### PR TITLE
Rename types to be explicit extends from d3 datum

### DIFF
--- a/packages/graph/src/collide-rectangle.ts
+++ b/packages/graph/src/collide-rectangle.ts
@@ -1,26 +1,28 @@
 import { quadtree, QuadtreeInternalNode, QuadtreeLeaf } from "d3-quadtree";
 
-import { GraphNode } from "./types";
+import { GraphNodeDatum } from "./types";
 
-function x(d: GraphNode) {
+function x(d: GraphNodeDatum) {
   return (d.x ?? 0) + (d.vx ?? 0);
 }
 
-function y(d: GraphNode) {
+function y(d: GraphNodeDatum) {
   return (d.y ?? 0) + (d.vy ?? 0);
 }
 
-function xCenterOfBox(d: GraphNode, box: number[]) {
+function xCenterOfBox(d: GraphNodeDatum, box: number[]) {
   return (d.x ?? 0) + box[0] + box[2] / 2;
 }
 
-function yCenterOfBox(d: GraphNode, box: number[]) {
+function yCenterOfBox(d: GraphNodeDatum, box: number[]) {
   return (d.y ?? 0) + box[1] + box[3] / 2;
 }
 
 // box is [x,y,width,height]
-function apply(d: GraphNode, box: number[], strength: number) {
-  return (quad: QuadtreeInternalNode<GraphNode> | QuadtreeLeaf<GraphNode>) => {
+function apply(d: GraphNodeDatum, box: number[], strength: number) {
+  return (
+    quad: QuadtreeInternalNode<GraphNodeDatum> | QuadtreeLeaf<GraphNodeDatum>,
+  ) => {
     if (quad.length === 4 || !d) {
       return;
     }
@@ -55,7 +57,7 @@ function apply(d: GraphNode, box: number[], strength: number) {
 }
 
 export default function (box: number[], strength = 0.4) {
-  let nodes: GraphNode[];
+  let nodes: GraphNodeDatum[];
   let iterations = 1;
   function force() {
     const tree = quadtree(nodes, x, y);
@@ -71,7 +73,7 @@ export default function (box: number[], strength = 0.4) {
     return arguments.length ? ((iterations = +_), force) : iterations;
   };
 
-  force.initialize = (_: GraphNode[]) =>
+  force.initialize = (_: GraphNodeDatum[]) =>
     (nodes = _.filter((node) => node.showLabel));
   return force;
 }

--- a/packages/graph/src/default-configuration.ts
+++ b/packages/graph/src/default-configuration.ts
@@ -1,7 +1,7 @@
 import { LinkType } from "@garden/types";
 import { SimulationNodeDatum } from "d3";
 
-import { GraphConfiguration, NodeLink } from "./types";
+import { GraphConfiguration, GraphLinkDatum } from "./types";
 
 const DEPTH_1_RADIUS = 30;
 const boundarySize = DEPTH_1_RADIUS * 4;
@@ -25,7 +25,7 @@ const linkTypeForceWeight = (linkType: LinkType) => {
   }
 };
 
-const linkDepthForceWeight = (link: NodeLink) =>
+const linkDepthForceWeight = (link: GraphLinkDatum) =>
   link.depth === 0
     ? 1.0
     : link.depth === 1
@@ -101,7 +101,7 @@ const defaultConfiguration = (
     linkDepthForceWeight,
 
     // How much each link attracts
-    getLinkForce: (factor: number) => (d: NodeLink) =>
+    getLinkForce: (factor: number) => (d: GraphLinkDatum) =>
       factor * linkTypeForceWeight(d.type) * linkDepthForceWeight(d),
   };
 };

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -8,16 +8,16 @@ import {
   GardenSimulation,
   Graph,
   GraphConfiguration,
-  GraphNode,
-  NodeLink,
+  GraphLinkDatum,
+  GraphNodeDatum,
 } from "./types";
 
 export type {
   GardenSimulation,
   Graph,
   GraphConfiguration,
-  GraphNode as Node,
-  NodeLink,
+  GraphLinkDatum,
+  GraphNodeDatum,
 };
 
 export { builder, collideRectangle, defaultConfiguration, itemName, render };

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -7,7 +7,7 @@ export enum NodeType {
   Thing = "thing",
 }
 
-export interface GraphNode extends SimulationNodeDatum {
+export interface GraphNodeDatum extends SimulationNodeDatum {
   id: string;
   title: string;
   context?: string;
@@ -18,14 +18,14 @@ export interface GraphNode extends SimulationNodeDatum {
   wanted: boolean;
 }
 
-export interface NodeLink extends SimulationLinkDatum<GraphNode> {
+export interface GraphLinkDatum extends SimulationLinkDatum<GraphNodeDatum> {
   type: LinkType;
   depth: number;
 }
 
 export interface Graph {
-  nodes: GraphNode[];
-  links: NodeLink[];
+  nodes: GraphNodeDatum[];
+  links: GraphLinkDatum[];
 }
 
 export interface InitialNodeValue {
@@ -59,11 +59,13 @@ export interface GraphConfiguration {
   centerForceFactor: number;
 
   depth: number;
-  getRadius: (d: GraphNode | SimulationNodeDatum) => number;
-  getCharge: (factor: number) => (d: GraphNode | SimulationNodeDatum) => number;
+  getRadius: (d: GraphNodeDatum | SimulationNodeDatum) => number;
+  getCharge: (
+    factor: number,
+  ) => (d: GraphNodeDatum | SimulationNodeDatum) => number;
   linkTypeForceWeight: (linkType: LinkType) => number;
-  linkDepthForceWeight: (link: NodeLink) => number;
-  getLinkForce: (factor: number) => (d: NodeLink) => number;
+  linkDepthForceWeight: (link: GraphLinkDatum) => number;
+  getLinkForce: (factor: number) => (d: GraphLinkDatum) => number;
 }
 
 export type GraphSelect = d3.Selection<


### PR DESCRIPTION
Towards decoupling of the graph from garden.  First make explicit interfaces based on d3 datum since I suspect these should all be internal details and it makes this undesired coupling easier to spot.